### PR TITLE
Add: Wait until fully healed functionality

### DIFF
--- a/src/app/client/connection.ts
+++ b/src/app/client/connection.ts
@@ -450,11 +450,14 @@ export const queueProcessCallback: CoreProcessCallback<ClientConnection> = async
 							attachHook
 								.then(() => {
 									this.registerShard({ playerUuid: message.body.playerUuid, shardUuid: message.body.shardUuid });
+									const player: ClientPlayer | undefined = shard.players.get(message.body.playerUuid);
+
 									message.body.units.forEach(unitUuid => {
 										shard.units.add(unitUuid);
+										if (player) {
+											player.units.add(unitUuid);
+										}
 									});
-
-									const player: ClientPlayer | undefined = shard.players.get(message.body.playerUuid);
 
 									if (player) {
 										updateDictionaryContainer({ dictionary: message.body.dictionary, dictionaryContainer: player });
@@ -608,9 +611,7 @@ export const queueProcessCallback: CoreProcessCallback<ClientConnection> = async
 									}
 								});
 
-								if (typeof emits.health === "number") {
-									this.universe.getEntity({ entityUuid }).health = emits.health;
-								}
+								entity.onUpdateDictionary();
 
 								// Reattach present
 								if (!targetCell.entities.has(entityUuid)) {

--- a/src/app/client/input.ts
+++ b/src/app/client/input.ts
@@ -40,6 +40,11 @@ export const leftSymbol: symbol = Symbol("left");
 export const waitSymbol: symbol = Symbol("wait");
 
 /**
+ * Identifier for the wait turn until fully healed input.
+ */
+export const waitUntilHealedSymbol: symbol = Symbol("wait-until-healed");
+
+/**
  * Identifier for the up right-click input.
  */
 export const rcSymbol: symbol = Symbol("right-click");

--- a/src/app/client/input.ts
+++ b/src/app/client/input.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 cpuabuse.com
+	Copyright 2024 cpuabuse.com
 	Licensed under the ISC License (https://opensource.org/licenses/ISC)
 */
 
@@ -33,6 +33,11 @@ export const rightSymbol: symbol = Symbol("right");
  * Identifier for the left movement input.
  */
 export const leftSymbol: symbol = Symbol("left");
+
+/**
+ * Identifier for the wait turn input.
+ */
+export const waitSymbol: symbol = Symbol("wait");
 
 /**
  * Identifier for the up right-click input.

--- a/src/app/client/progess-bar.ts
+++ b/src/app/client/progess-bar.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 cpuabuse.com
+	Copyright 2024 cpuabuse.com
 	Licensed under the ISC License (https://opensource.org/licenses/ISC)
 */
 
@@ -333,5 +333,13 @@ export class ProgressBar {
 		this.mesh = new Mesh(ProgressBar.geometry, this.shader);
 		this.scale = scale;
 		this.container.addChild(this.mesh);
+	}
+
+	/**
+	 * Remove progress bar dependencies from graphical memory, but preserve static objects for use by other bars.
+	 */
+	public destroy(): void {
+		this.mesh.destroy();
+		this.shader.destroy();
 	}
 }

--- a/src/app/client/shard.ts
+++ b/src/app/client/shard.ts
@@ -46,7 +46,8 @@ import {
 	rightSymbol,
 	scrollSymbol,
 	upSymbol,
-	waitSymbol
+	waitSymbol,
+	waitUntilHealedSymbol
 } from "./input";
 import { ClientOptions, clientOptions } from "./options";
 import { uuidToName } from "./text";
@@ -312,6 +313,17 @@ export function ClientShardFactory({
 								level: LogLevel.Alert
 							});
 						}
+					});
+
+					// Add listeners for wait turn until fully healed input
+					// Async callback for event emitter
+					// eslint-disable-next-line @typescript-eslint/no-misused-promises
+					this.input.on(waitUntilHealedSymbol, inputInterface => {
+						// #if _DEBUG_ENABLED
+						inputDebug({ input: inputInterface as InputInterface, symbol: waitUntilHealedSymbol });
+						// #endif
+
+						// TODO: Check if there is no surrounding monsters, and health is not fully healed
 					});
 
 					let movementInputEntries: [symbol: symbol, direction: MovementWord][] = [

--- a/src/app/client/universe.ts
+++ b/src/app/client/universe.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 cpuabuse.com
+	Copyright 2024 cpuabuse.com
 	Licensed under the ISC License (https://opensource.org/licenses/ISC)
 */
 
@@ -47,7 +47,8 @@ import {
 	rcSymbol,
 	rightSymbol,
 	scrollSymbol,
-	upSymbol
+	upSymbol,
+	waitSymbol
 } from "./input";
 import { ClientMode } from "./mode";
 import { ClientOptions, clientOptions } from "./options";
@@ -513,6 +514,16 @@ export class ClientUniverse extends CoreUniverseClassFactory<
 				mousetrap.bind("e", () => {
 					this.shards.forEach(clientShard => {
 						clientShard.fireInput(localActionSymbol, {
+							x: 0,
+							y: 0
+						});
+					});
+				});
+				// We don't care about return
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				mousetrap.bind("r", () => {
+					this.shards.forEach(clientShard => {
+						clientShard.fireInput(waitSymbol, {
 							x: 0,
 							y: 0
 						});

--- a/src/app/client/universe.ts
+++ b/src/app/client/universe.ts
@@ -48,7 +48,8 @@ import {
 	rightSymbol,
 	scrollSymbol,
 	upSymbol,
-	waitSymbol
+	waitSymbol,
+	waitUntilHealedSymbol
 } from "./input";
 import { ClientMode } from "./mode";
 import { ClientOptions, clientOptions } from "./options";
@@ -524,6 +525,17 @@ export class ClientUniverse extends CoreUniverseClassFactory<
 				mousetrap.bind("r", () => {
 					this.shards.forEach(clientShard => {
 						clientShard.fireInput(waitSymbol, {
+							x: 0,
+							y: 0
+						});
+					});
+				});
+
+				// We don't care about return
+				// eslint-disable-next-line @typescript-eslint/no-unsafe-call
+				mousetrap.bind("t", () => {
+					this.shards.forEach(clientShard => {
+						clientShard.fireInput(waitUntilHealedSymbol, {
 							x: 0,
 							y: 0
 						});

--- a/src/app/common/defaults/connection.ts
+++ b/src/app/common/defaults/connection.ts
@@ -54,7 +54,12 @@ export enum MessageTypeWord {
 	/**
 	 * Notification about action result, or any turn by turn quick information.
 	 */
-	StatusNotification = "status-notification"
+	StatusNotification = "status-notification",
+
+	/**
+	 * Client sends information about a player skipping his turn to play.
+	 */
+	Wait = "wait"
 }
 
 /**

--- a/src/app/common/defaults/connection.ts
+++ b/src/app/common/defaults/connection.ts
@@ -59,7 +59,12 @@ export enum MessageTypeWord {
 	/**
 	 * Client sends information about a player skipping his turn to play.
 	 */
-	Wait = "wait"
+	Wait = "wait",
+
+	/**
+	 * Client sends information about a player ending his turn.
+	 */
+	Turn = "turn"
 }
 
 /**

--- a/src/app/core/connection/message.ts
+++ b/src/app/core/connection/message.ts
@@ -86,6 +86,16 @@ export interface CoreMessageMovement extends CoreMessageBase {
 }
 
 /**
+ * Turn message interface.
+ */
+export interface CoreMessageTurn extends CoreMessageBase {
+	/**
+	 * Type of the message.
+	 */
+	type: MessageTypeWord.Turn;
+}
+
+/**
  * Empty message interface.
  */
 export interface CoreMessageEmpty extends CoreMessageBase {

--- a/src/app/core/connection/message.ts
+++ b/src/app/core/connection/message.ts
@@ -1,5 +1,5 @@
 /*
-	Copyright 2023 cpuabuse.com
+	Copyright 2024 cpuabuse.com
 	Licensed under the ISC License (https://opensource.org/licenses/ISC)
 */
 
@@ -113,6 +113,27 @@ export interface CoreMessageSync extends CoreMessageBase {
 	 * Type of the message.
 	 */
 	type: MessageTypeWord.Sync;
+}
+
+/**
+ *  Message for when a player waits/skips his turn.
+ */
+export interface CoreMessageWait extends CoreMessageBase {
+	/**
+	 * Message data.
+	 */
+	body: CoreMessagePlayerBody & {
+		// TODO: Remove, as not needed
+		/**
+		 * Unit UUID.
+		 */
+		unitUuid: Uuid;
+	};
+
+	/**
+	 * Type of the message.
+	 */
+	type: MessageTypeWord.Wait;
 }
 
 /**

--- a/src/app/vue/views/universe-ui-toolbar-welcome.vue
+++ b/src/app/vue/views/universe-ui-toolbar-welcome.vue
@@ -148,7 +148,8 @@ export default defineComponent({
 				],
 				[
 					{ description: "Use", keyboardKey: "E", subtext: "(Use the ladder to descend)" },
-					{ description: "Wait", keyboardKey: "R", subtext: "(Skip your turn)" }
+					{ description: "Wait", keyboardKey: "R", subtext: "(Skip your turn)" },
+					{ description: "Wait until healed", keyboardKey: "T", subtext: "(Or event/danger)" }
 				]
 			]
 		};

--- a/src/app/vue/views/universe-ui-toolbar-welcome.vue
+++ b/src/app/vue/views/universe-ui-toolbar-welcome.vue
@@ -149,7 +149,7 @@ export default defineComponent({
 				[
 					{ description: "Use", keyboardKey: "E", subtext: "(Use the ladder to descend)" },
 					{ description: "Wait", keyboardKey: "R", subtext: "(Skip your turn)" },
-					{ description: "Wait until healed", keyboardKey: "T", subtext: "(Or event/danger)" }
+					{ description: "Start/stop waiting until healed", keyboardKey: "T", subtext: "(Or event/danger)" }
 				]
 			]
 		};

--- a/src/app/vue/views/universe-ui-toolbar-welcome.vue
+++ b/src/app/vue/views/universe-ui-toolbar-welcome.vue
@@ -146,7 +146,10 @@ export default defineComponent({
 					{ description: "Camera level up", keyboardKey: "O" },
 					{ description: "Camera level down", keyboardKey: "P" }
 				],
-				[{ description: "Use", keyboardKey: "E", subtext: "(Use the ladder to descend)" }]
+				[
+					{ description: "Use", keyboardKey: "E", subtext: "(Use the ladder to descend)" },
+					{ description: "Wait", keyboardKey: "R", subtext: "(Skip your turn)" }
+				]
 			]
 		};
 	}


### PR DESCRIPTION
## Description

This PR introduces a 'Wait Until Fully Healed' feature. By pressing the "t" key, players can now opt to wait or skip turns until their health is fully restored. Any other input during this process will cancel the event.

## Changes

- Add:  Wait/skip turns until full health is achieved
- Add: Cancel the wait/skip turns process upon any input
- Change: Welcome screen with a description of this new feature